### PR TITLE
Setup Spotify Login

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,14 +1,39 @@
+import { redirect } from "react-router-dom";
 import { UserCredentials } from "../types";
 
 export async function RegisterUser(user: UserCredentials) {
+  
   const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/register`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(user),
+    credentials: "include"
   });
   if (!response.ok) {
     console.log("error occured in response");
   }
+  console.log("Register function probably succeeded");
+  
+}
+
+export async function LoginUser(user: UserCredentials) {
+  
+  const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(user),
+    credentials: "include"
+  });
+  if (!response.ok) {
+    console.log("error occured in login response");
+  }
+  if(response.status === 307) {
+    window.location.href = "/"
+  }
+  console.log("Login function probably succeeded");
+  
 }

--- a/client/src/components/LoginPage.tsx
+++ b/client/src/components/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { UserCredentials } from "../types";
-import { RegisterUser } from "../api/auth";
-export default function RegisterPage() {
+import { LoginUser } from "../api/auth";
+export default function LoginPage() {
   const emptyUser: UserCredentials = { username: "", password: "" };
   const [user, setUser] = useState<UserCredentials>(emptyUser);
 
@@ -13,9 +13,9 @@ export default function RegisterPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log(user);
-    RegisterUser(user)
+    LoginUser(user)
       .catch((err) => {
-        console.log(`error in registerUser: ${err}`);
+        console.log(`error in loginUser: ${err}`);
     })
   };
 

--- a/client/src/components/Root.tsx
+++ b/client/src/components/Root.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 export default function Root() {
   return (
     <>
@@ -9,7 +11,13 @@ export default function Root() {
           <h1>wsg gang</h1>
         </div>
         <div className="border-black border-[1px] rounded-sm p-3">
-          <h1>wsg gang</h1>
+          <Link to="/register">Register</Link>
+        </div>
+        <div className="border-black border-[1px] rounded-sm p-3">
+          <Link to="/login">login</Link>
+        </div>
+        <div className="border-black border-[1px] rounded-sm p-3">
+          <Link to="/spotify">Login with Spotify</Link>
         </div>
       </div>
     </>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,7 @@ import Root from "./components/Root.tsx";
 import RegisterPage from "./components/RegisterPage.tsx";
 import ErrorPage from "./components/ErrorPage.tsx";
 import "./index.css";
+import LoginPage from "./components/LoginPage.tsx";
 
 const router = createBrowserRouter([
   {
@@ -24,6 +25,10 @@ const router = createBrowserRouter([
     path: "/register",
     element: <RegisterPage />,
   },
+  {
+    path: "/login",
+    element: <LoginPage />
+  }
 ]);
 
 createRoot(document.getElementById("root")!).render(

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,10 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@types/cookie-parser": "^1.4.7",
+        "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/pg": "^8.11.8",
         "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
@@ -122,6 +124,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/express": {
@@ -536,6 +547,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1226,6 +1250,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/server/package.json
+++ b/server/package.json
@@ -11,10 +11,12 @@
   "description": "",
   "dependencies": {
     "@types/cookie-parser": "^1.4.7",
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/pg": "^8.11.8",
     "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",

--- a/server/src/auth/jwt.ts
+++ b/server/src/auth/jwt.ts
@@ -6,5 +6,6 @@ export const createJwt = (username: string) => {
 
 export const jwtCookieOptions = {
     maxAge: 1000 * 60 * 15, 
-    httpOnly: true
+    secure: false,
+    httpOnly: true,
 }

--- a/server/src/handlers/login.ts
+++ b/server/src/handlers/login.ts
@@ -9,7 +9,7 @@ export const loginHandler = async (req: Request, res: Response) => {
     const parsedCookies = authCookiesSchema.safeParse(req.cookies)
     if(parsedCookies.success && parsedCookies.data.auth_token) {
         console.log(`Redirecting from /login to / from auth_token = ${parsedCookies.data.auth_token}`);
-        res.redirect("/")
+        res.sendStatus(307)
         return
     }
     

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,18 +1,27 @@
 import express from "express";
 import cookieParser from 'cookie-parser'
+import cors from "cors"
 import { registerHandler } from "./handlers/register";
 import { clearUsersHandler, getUsersHandler } from "./handlers/userHandler";
 import { loginHandler } from "./handlers/login";
+import { spotifyLoginHandler, spotifyCallbackHandler } from "./handlers/spotifyHandler";
+import "dotenv/config"
 
 const app = express();
 const port = 3000;
 
+var corsOptions = {
+  origin: 'http://localhost:5173',
+  credentials: true,
+}
+
+app.use(cors(corsOptions))
 app.use(express.json())
 app.use(cookieParser())
 
 app.get("/", (req, res) => {
-  res.send("Express + TypeScript Server hello");
   console.log("GET request from home route received");
+  res.send("Express + TypeScript Server hello");
 });
 
 app.get("/users", getUsersHandler)
@@ -21,6 +30,9 @@ app.post("/users", clearUsersHandler)
 
 app.post("/register", registerHandler)
 app.post("/login", loginHandler)
+
+app.get("/spotify", spotifyLoginHandler)
+app.get('/auth/callback', spotifyCallbackHandler )
 
 
 app.listen(port, () => {


### PR DESCRIPTION
## Overview 
- On GET request to /spotify
  - users should be redirected to spotify's endpoint and log in with spotify credentials
  - Once they log in, they should be redirected back to the home page (send a redirect status code)
  - Send a JSON containing their spotify access token, and (in future PR) save this to Context, most likely 