### PR TITLE
Synchronize Continue Signal

### DIFF
--- a/client/src/components/common/Navbar.tsx
+++ b/client/src/components/common/Navbar.tsx
@@ -25,14 +25,13 @@ export const NavbarLink = ({
 
 interface Props {
     enableRoomcode?: boolean;
+    className?: string;
 }
 
-export default function Navbar({ enableRoomcode = false }: Props) {
+export default function Navbar({ enableRoomcode = false, className = "" }: Props) {
     const user = useUser();
     const socket = useContext(WebsocketContext);
-    const [clipboardSuccess, setClipboardSuccess] = useState<boolean | undefined>(
-        undefined
-    );
+    const [clipboardSuccess, setClipboardSuccess] = useState<boolean | undefined>(undefined);
     const handleClipboard = async () => {
         try {
             await navigator.clipboard.writeText(socket.roomCode);
@@ -48,27 +47,20 @@ export default function Navbar({ enableRoomcode = false }: Props) {
     }, [socket.roomCode]);
 
     return (
-        <nav className="border-[1px] border-transparent w-full flex justify-between items-center p-2 transition-colors duration-500 hover:border-b-offwhite/30">
+        <nav
+            className={`border-[1px] border-transparent w-full flex justify-between items-center p-2 transition-colors duration-500 hover:border-b-offwhite/30 ${className}`}
+        >
             <div className="text-6xl text-main-green font-bebas w-3/5 pl-16 flex justify-between">
                 TRACK DUEL
                 {socket.roomCode && enableRoomcode && (
                     <header className="text-5xl text-offwhite my-4 flex gap-3">
                         <p>
                             Room Code:{" "}
-                            <span className="text-main-green text-5xl">
-                                {socket.roomCode}
-                            </span>
+                            <span className="text-main-green text-5xl">{socket.roomCode}</span>
                         </p>
-                        <button
-                            onClick={handleClipboard}
-                            className="text-xl text-offwhite"
-                        >
+                        <button onClick={handleClipboard} className="text-xl text-offwhite">
                             <img
-                                src={
-                                    clipboardSuccess
-                                        ? "/check-square.svg"
-                                        : "/clipboard.svg"
-                                }
+                                src={clipboardSuccess ? "/check-square.svg" : "/clipboard.svg"}
                                 height={35}
                                 width={35}
                             />

--- a/client/src/components/duel/ActiveLobby.tsx
+++ b/client/src/components/duel/ActiveLobby.tsx
@@ -12,12 +12,10 @@ import { updateTracks } from "../../store/state/trackSelectionState";
 import PlaylistSelection from "../common/PlaylistsSelection";
 import PlayersContainer from "./PlayersContainer";
 import LockedPlaylist from "./LockedPlaylist";
-import { useLocation } from "react-router-dom";
 
 export default function ActiveLobby() {
     const socket = useContext(WebsocketContext);
     const dispatch = useAppDispatch();
-    const location = useLocation();
     const [getSavedPlaylistsError, setSavedPlaylistsError] = useState("");
     const [savedPlaylists, setSavedPlaylists] = useState<string[]>([]);
     const [offset, setOffset] = useState(savedPlaylists.length);
@@ -202,11 +200,11 @@ export default function ActiveLobby() {
                             </>
                         )}
                     </div>
-                    <div className="border-[1px] w-1/5 w-2/5 border-offwhite/60 text-offwhite">
+                    <div className="border-[1px]  w-2/5 border-offwhite/60 text-offwhite">
                         <header className="text-2xl text-offwhite font-semibold font-kanit text-center">
                             Connected Gooners
                         </header>
-                        <PlayersContainer players={socket.lobby} />
+                        <PlayersContainer players={Object.keys(socket.lobby)} />
                     </div>
                 </div>
             </div>

--- a/client/src/components/duel/ActiveLobby.tsx
+++ b/client/src/components/duel/ActiveLobby.tsx
@@ -123,13 +123,12 @@ export default function ActiveLobby() {
                                             uri={confirmedPlaylistUri}
                                             imageSize={300}
                                         />
-                                        {isSuccess && (
-                                            <Button
-                                                content="Start Duel"
-                                                className="text-4xl px-6 w-full py-3 font-bebas border-red-600 tracking-wide  text-red-600 hover:bg-red-600 hover:text-black "
-                                                onClick={() => socket.startDuel()}
-                                            />
-                                        )}
+                                        <Button
+                                            content="Start Duel"
+                                            className="text-4xl px-6 w-full py-3 font-bebas border-red-600 tracking-wide  text-red-600 hover:bg-red-600 hover:text-black "
+                                            onClick={() => socket.startDuel()}
+                                            disabled={isLoading}
+                                        />
                                         <img
                                             src="/skullfire.png"
                                             height={200}

--- a/client/src/components/duel/DuelChat.tsx
+++ b/client/src/components/duel/DuelChat.tsx
@@ -1,0 +1,59 @@
+import { useContext, useEffect, useRef } from "react";
+import { WebsocketContext } from "./Duel";
+
+interface Props {
+    className?: string;
+    children?: React.ReactNode;
+}
+
+export default function DuelChat({ className = "", children }: Props) {
+    const socket = useContext(WebsocketContext);
+    const chatContainerRef = useRef<HTMLDivElement | null>(null);
+
+    const scrollToBottom = () => {
+        const container = chatContainerRef.current;
+        if (container) {
+            container.scrollTop = container.scrollHeight;
+        }
+    };
+
+    useEffect(() => {
+        scrollToBottom();
+    }, [socket.answers]);
+
+    return (
+        <div className={className}>
+            <div
+                className="border-2 border-gray-500 p-5 w-full h-4/5 overflow-y-auto"
+                ref={chatContainerRef}
+            >
+                {socket.answers.length === 0 && (
+                    <p className="text-xl text-surface75 text-center">
+                        Dead chat... Someone say something
+                    </p>
+                )}
+                {socket.answers.map((answer, i) => {
+                    const answerStyle =
+                        "border-b-[1px] border-b-offwhite border-spacing-1 text-xl font-lato my-2";
+                    if (answer.isCorrect) {
+                        return (
+                            <p className={`text-main-green  ${answerStyle}`}>
+                                {answer.from} guessed the song correctly!
+                            </p>
+                        );
+                    } else
+                        return (
+                            <p
+                                className={`${answerStyle} ${
+                                    i % 2 === 0 ? "text-offwhite " : " text-surface75"
+                                }`}
+                            >
+                                <strong>{answer.from}:</strong> {answer.answer}
+                            </p>
+                        );
+                })}
+            </div>
+            {children}
+        </div>
+    );
+}

--- a/client/src/components/duel/GamePlaylist.tsx
+++ b/client/src/components/duel/GamePlaylist.tsx
@@ -1,0 +1,25 @@
+import Marquee from "../common/Marquee";
+import usePlaylist from "../../hooks/usePlaylist";
+
+interface Props {
+    className?: string;
+}
+
+export default function GamePlaylist({ className = "" }: Props) {
+    const playlist = usePlaylist();
+
+    return (
+        <div className={` ${className} `}>
+            <img src={playlist.images[0].url} height={150} width={150} />
+            {Array.from({ length: 10 }).map((_, i) => (
+                <Marquee
+                    content={playlist.name}
+                    className={`text-2xl tracking-wider ${
+                        i % 2 === 0 ? "text-offwhite " : " !bg-white !text-black"
+                    }`}
+                    reverse={i % 2 !== 0}
+                />
+            ))}
+        </div>
+    );
+}

--- a/client/src/components/duel/GamePlaylist.tsx
+++ b/client/src/components/duel/GamePlaylist.tsx
@@ -1,25 +1,69 @@
 import Marquee from "../common/Marquee";
 import usePlaylist from "../../hooks/usePlaylist";
+import useTrackSelection from "../../hooks/useTrackSelection";
+import { useEffect, useState } from "react";
 
 interface Props {
     className?: string;
+    trackIndex?: number;
+    displayPreviousTrack?: boolean;
 }
 
-export default function GamePlaylist({ className = "" }: Props) {
+export default function GamePlaylist({
+    className = "",
+    trackIndex,
+    displayPreviousTrack = false,
+}: Props) {
     const playlist = usePlaylist();
+    const trackSelection = useTrackSelection();
+    const [currentTrackData, setTrackData] = useState<string[]>([]);
+
+    useEffect(() => {
+        if (trackIndex === undefined) return;
+        const currentTrack = trackSelection[trackIndex];
+        setTrackData([
+            `Song: ${currentTrack.name}`,
+            `Artist: ${currentTrack.artists[0].name}`,
+            `Album: ${currentTrack.album.name}`,
+        ]);
+    }, [trackIndex]);
 
     return (
         <div className={` ${className} `}>
-            <img src={playlist.images[0].url} height={150} width={150} />
-            {Array.from({ length: 10 }).map((_, i) => (
-                <Marquee
-                    content={playlist.name}
-                    className={`text-2xl tracking-wider ${
-                        i % 2 === 0 ? "text-offwhite " : " !bg-white !text-black"
-                    }`}
-                    reverse={i % 2 !== 0}
-                />
-            ))}
+            <img
+                src={
+                    displayPreviousTrack && trackIndex !== undefined
+                        ? trackSelection[trackIndex].album.images[0].url
+                        : playlist.images[0].url
+                }
+                height={150}
+                width={150}
+            />
+
+            {Array.from({ length: 10 }).map((_, i) => {
+                const dataIndex = i % 3;
+                const isEven = i % 2 === 0;
+                if (displayPreviousTrack && trackIndex !== undefined) {
+                    return (
+                        <Marquee
+                            content={currentTrackData[dataIndex]}
+                            className={`text-2xl tracking-wider ${
+                                isEven ? "text-offwhite " : " !bg-white !text-black"
+                            }`}
+                            reverse={isEven}
+                        />
+                    );
+                }
+                return (
+                    <Marquee
+                        content={playlist.name}
+                        className={`text-2xl tracking-wider ${
+                            isEven ? "text-offwhite " : " !bg-white !text-black"
+                        }`}
+                        reverse={isEven}
+                    />
+                );
+            })}
         </div>
     );
 }

--- a/client/src/components/duel/InactiveLobby.tsx
+++ b/client/src/components/duel/InactiveLobby.tsx
@@ -43,10 +43,12 @@ export default function InactiveLobby() {
             <img src="/matrix.png" width={300} height={300} />
             <div
                 className={`flex w-1/3 ${
-                    socket.lobby.length > 0 ? "justify-center" : "justify-between"
+                    Object.keys(socket.lobby).length > 0
+                        ? "justify-center"
+                        : "justify-between"
                 }`}
             >
-                {socket.lobby.length === 0 && (
+                {Object.keys(socket.lobby).length === 0 && (
                     <>
                         <Button
                             content="Create Room"

--- a/client/src/components/duel/Scoreboard.tsx
+++ b/client/src/components/duel/Scoreboard.tsx
@@ -1,0 +1,29 @@
+import { useContext } from "react";
+import { WebsocketContext } from "./Duel";
+
+interface Props {
+    className?: string;
+}
+export default function Scoreboard({ className = "" }: Props) {
+    const socket = useContext(WebsocketContext);
+
+    return (
+        <div className={`${className}`}>
+            <p className="text-4xl tracking-wide text-offwhite font-semibold font-bebas border-b-2 border-b-offwhite border-spacing-1">
+                SCOREBOARD
+            </p>
+            <div className=" w-full">
+                {Object.entries(socket.lobby).map(([player, data], i) => (
+                    <p
+                        className={`font-kanit text-2xl px-3 py-2 ${
+                            i % 2 === 0 ? "text-offwhite" : "text-black bg-offwhite"
+                        }`}
+                        key={player}
+                    >
+                        {player}: {data.score}
+                    </p>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/client/src/components/duel/TrackDuel.tsx
+++ b/client/src/components/duel/TrackDuel.tsx
@@ -61,13 +61,12 @@ export default function TrackDuel() {
         e.preventDefault();
         setAnswer("");
         if (isCorrectAnswer(answer)) {
-            socket.broadcastCorrectAnswer();
             setCorrect(true);
             setPlay(false);
             const elapsedTimeSeconds = Math.round((Date.now() - startTime) / 1000);
-            if (elapsedTimeSeconds < 100) {
-                setScore((prev) => prev + (100 - elapsedTimeSeconds));
-            }
+            if (elapsedTimeSeconds >= 100) return;
+            const updatedScore = score + (100 - elapsedTimeSeconds);
+            socket.broadcastCorrectAnswer(updatedScore);
         } else {
             socket.sendAnswer(answer);
         }
@@ -76,7 +75,6 @@ export default function TrackDuel() {
     const selectNextSong = () => {
         if (currentTrackIndex >= randomTracks.length - 1) return;
         setAnswer("");
-        // socket.resetAnswers();
         setCurrentTrackIndex((prev) => prev + 1);
         setCorrect(false);
         setPlay(true);
@@ -90,19 +88,16 @@ export default function TrackDuel() {
         }
     };
 
-    // useEffect hook to scroll to the bottom when new messages are added
     useEffect(() => {
         scrollToBottom();
-    }, [socket.answers]); // This runs whenever the messages state changes
+    }, [socket.answers]);
 
     return (
         <BlackBackground>
             <Navbar enableRoomcode={false} />
             {/* <div className="flex flex-col items-center h-screen"> */}
             <div className="flex justify-center gap-8 h-screen mt-24">
-                {socket.loading && (
-                    <p className="text-offwhite">Establishing connection...</p>
-                )}
+                {socket.loading && <p className="text-offwhite">Establishing connection...</p>}
                 <div className="w-1/5 h-[64%] p-3 flex flex-col items-center overflow-x-hidden border-[1px] border-gray-500">
                     <img src={playlist.images[0].url} height={150} width={150} />
                     {Array.from({ length: 8 }).map((_, i) => (
@@ -153,9 +148,7 @@ export default function TrackDuel() {
                                 return (
                                     <p
                                         className={`${answerStyle} ${
-                                            i % 2 === 0
-                                                ? "text-offwhite "
-                                                : " text-surface75"
+                                            i % 2 === 0 ? "text-offwhite " : " text-surface75"
                                         }`}
                                     >
                                         <strong>{answer.from}:</strong> {answer.answer}
@@ -180,14 +173,17 @@ export default function TrackDuel() {
                         />
                     </form>
                 </div>
-                <div className=" border-[1px] border-gray-500 w-1/5 h-[64%]">
-                    <p className="text-2xl text-offwhite">SCOREBOARD</p>
-                    <p className="text-xl text-red-700">
+                <div className="flex flex-col items-center border-[1px] border-gray-500 w-1/5 h-[64%]">
+                    <p className="text-2xl text-offwhite font-semibold font-bebas">SCOREBOARD</p>
+                    {Object.entries(socket.lobby).map(([player, data]) => (
+                        <p className="text-xl text-offwhite font-kanit">
+                            {player}: {data.score}
+                        </p>
+                    ))}
+                    {/* <p className="text-xl text-offwhite">
                         {userStore.username}: {score}
-                    </p>
-                    {songBreak && (
-                        <p className="text-2xl text-blue-500">IN SONG BREAK STATE</p>
-                    )}
+                    </p> */}
+                    {songBreak && <p className="text-2xl text-blue-500">IN SONG BREAK STATE</p>}
                 </div>
             </div>
         </BlackBackground>

--- a/client/src/components/duel/TrackDuel.tsx
+++ b/client/src/components/duel/TrackDuel.tsx
@@ -19,6 +19,7 @@ export default function TrackDuel() {
     const [play, setPlay] = useState<boolean>(false);
     const [startTime, setStartTime] = useState<number>(0);
     const [currentTrackIndex, setCurrentTrackIndex] = useState<number>(0);
+    const [songBreak, setSongBreak] = useState(false);
     const [answer, setAnswer] = useState("");
     const [correct, setCorrect] = useState<boolean>(false);
     const [score, setScore] = useState<number>(0);
@@ -44,6 +45,18 @@ export default function TrackDuel() {
             setStartTime(Date.now());
         }
     }, [play]);
+
+    useEffect(() => {
+        if (socket.continueSignal === 0) return;
+        setSongBreak(true);
+        setPlay(false);
+
+        setTimeout(() => {
+            setSongBreak(false);
+            // setCurrentTrackIndex((prev) => prev + 1);
+            selectNextSong();
+        }, 5000);
+    }, [socket.continueSignal]);
 
     const handleSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -173,6 +186,9 @@ export default function TrackDuel() {
                     <p className="text-xl text-red-700">
                         {userStore.username}: {score}
                     </p>
+                    {songBreak && (
+                        <p className="text-2xl text-blue-500">IN SONG BREAK STATE</p>
+                    )}
                 </div>
             </div>
         </BlackBackground>

--- a/client/src/components/duel/TrackDuel.tsx
+++ b/client/src/components/duel/TrackDuel.tsx
@@ -49,6 +49,7 @@ export default function TrackDuel() {
         e.preventDefault();
         setAnswer("");
         if (isCorrectAnswer(answer)) {
+            socket.broadcastCorrectAnswer();
             setCorrect(true);
             setPlay(false);
             const elapsedTimeSeconds = Math.round((Date.now() - startTime) / 1000);
@@ -127,15 +128,28 @@ export default function TrackDuel() {
                                 Dead chat... Someone say something
                             </p>
                         )}
-                        {socket.answers.map((answer, i) => (
-                            <p
-                                className={`${
-                                    i % 2 === 0 ? "text-offwhite " : "text-main-green"
-                                } border-b-[1px] border-b-offwhite border-spacing-1 text-xl font-lato my-2`}
-                            >
-                                <strong>{answer.from}:</strong> {answer.answer}
-                            </p>
-                        ))}
+                        {socket.answers.map((answer, i) => {
+                            const answerStyle =
+                                "border-b-[1px] border-b-offwhite border-spacing-1 text-xl font-lato my-2";
+                            if (answer.isCorrect) {
+                                return (
+                                    <p className={`text-main-green  ${answerStyle}`}>
+                                        {answer.from} guessed the song correctly!
+                                    </p>
+                                );
+                            } else
+                                return (
+                                    <p
+                                        className={`${answerStyle} ${
+                                            i % 2 === 0
+                                                ? "text-offwhite "
+                                                : " text-surface75"
+                                        }`}
+                                    >
+                                        <strong>{answer.from}:</strong> {answer.answer}
+                                    </p>
+                                );
+                        })}
                     </div>
                     <form onSubmit={handleSubmit} className="w-full">
                         <input

--- a/client/src/components/duel/TrackDuel.tsx
+++ b/client/src/components/duel/TrackDuel.tsx
@@ -45,14 +45,14 @@ export default function TrackDuel() {
     }, [play]);
 
     useEffect(() => {
-        if (socket.continueSignal === 0) return;
+        if (socket.continueSignal <= 0) return;
         setSongBreak(true);
         setPlay(false);
 
         setTimeout(() => {
             setSongBreak(false);
             selectNextSong();
-        }, 5000);
+        }, 4000);
     }, [socket.continueSignal]);
 
     const handleSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
@@ -73,8 +73,10 @@ export default function TrackDuel() {
     const selectNextSong = () => {
         if (currentTrackIndex >= randomTracks.length - 1) return;
         setAnswer("");
-        setCurrentTrackIndex((prev) => prev + 1);
         setCorrect(false);
+        if (socket.continueSignal > 1) {
+            setCurrentTrackIndex((prev) => prev + 1);
+        }
         setPlay(true);
         setStartTime(Date.now());
     };
@@ -108,12 +110,6 @@ export default function TrackDuel() {
                         />
                     ))}
                     <div className=" flex flex-col gap-3 py-2">
-                        <Button
-                            onClick={() => selectNextSong()}
-                            className="text-md text-offwhite border-offwhite"
-                            content="Select Next Song"
-                        />
-
                         <Player
                             accessToken={getSpotifyToken()}
                             trackUri={randomTracks?.[currentTrackIndex].uri}

--- a/client/src/components/duel/TrackDuel.tsx
+++ b/client/src/components/duel/TrackDuel.tsx
@@ -53,7 +53,6 @@ export default function TrackDuel() {
 
         setTimeout(() => {
             setSongBreak(false);
-            // setCurrentTrackIndex((prev) => prev + 1);
             selectNextSong();
         }, 5000);
     }, [socket.continueSignal]);

--- a/client/src/components/duel/TrackDuel.tsx
+++ b/client/src/components/duel/TrackDuel.tsx
@@ -8,11 +8,10 @@ import { WebsocketContext } from "./Duel";
 import Player from "../common/Player";
 import Navbar from "../common/Navbar";
 import Button from "../common/Button";
-import useUser from "../../hooks/useUser";
 import Marquee from "../common/Marquee";
+import Scoreboard from "./Scoreboard";
 
 export default function TrackDuel() {
-    const userStore = useUser();
     const randomTracks = useTrackSelection();
     const playlist = usePlaylist();
     const navigate = useNavigate();
@@ -22,7 +21,6 @@ export default function TrackDuel() {
     const [songBreak, setSongBreak] = useState(false);
     const [answer, setAnswer] = useState("");
     const [correct, setCorrect] = useState<boolean>(false);
-    const [score, setScore] = useState<number>(0);
     const socket = useContext(WebsocketContext);
     const chatContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -59,17 +57,17 @@ export default function TrackDuel() {
 
     const handleSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
         e.preventDefault();
-        setAnswer("");
         if (isCorrectAnswer(answer)) {
             setCorrect(true);
             setPlay(false);
             const elapsedTimeSeconds = Math.round((Date.now() - startTime) / 1000);
             if (elapsedTimeSeconds >= 100) return;
-            const updatedScore = score + (100 - elapsedTimeSeconds);
-            socket.broadcastCorrectAnswer(updatedScore);
+            const pointsScored = 100 - elapsedTimeSeconds;
+            socket.broadcastCorrectAnswer(pointsScored);
         } else {
             socket.sendAnswer(answer);
         }
+        setAnswer("");
     };
 
     const selectNextSong = () => {
@@ -95,7 +93,7 @@ export default function TrackDuel() {
     return (
         <BlackBackground>
             <Navbar enableRoomcode={false} />
-            {/* <div className="flex flex-col items-center h-screen"> */}
+            {songBreak && <p className="text-md text-blue-500 font-lato">SONG BREAK</p>}
             <div className="flex justify-center gap-8 h-screen mt-24">
                 {socket.loading && <p className="text-offwhite">Establishing connection...</p>}
                 <div className="w-1/5 h-[64%] p-3 flex flex-col items-center overflow-x-hidden border-[1px] border-gray-500">
@@ -173,18 +171,16 @@ export default function TrackDuel() {
                         />
                     </form>
                 </div>
-                <div className="flex flex-col items-center border-[1px] border-gray-500 w-1/5 h-[64%]">
+                <Scoreboard className="flex flex-col items-center border-[1px] border-gray-500 w-1/5 h-[64%] p-4" />
+                {/* <div className="flex flex-col items-center border-[1px] border-gray-500 w-1/5 h-[64%]">
                     <p className="text-2xl text-offwhite font-semibold font-bebas">SCOREBOARD</p>
                     {Object.entries(socket.lobby).map(([player, data]) => (
                         <p className="text-xl text-offwhite font-kanit">
                             {player}: {data.score}
                         </p>
                     ))}
-                    {/* <p className="text-xl text-offwhite">
-                        {userStore.username}: {score}
-                    </p> */}
                     {songBreak && <p className="text-2xl text-blue-500">IN SONG BREAK STATE</p>}
-                </div>
+                </div> */}
             </div>
         </BlackBackground>
     );

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -14,6 +14,7 @@ enum SocketResponse {
     RoomUpdate = "room-update",
     LeftRoom = "left-room",
     Playlist = "playlist",
+    Correct = "correct",
 }
 
 enum SocketRequest {
@@ -22,6 +23,7 @@ enum SocketRequest {
     StartDuel = "start-duel",
     SendPlaylist = "send-playlist",
     Answer = "answer",
+    Correct = "correct",
 }
 
 export default function useWebsocketSetup() {
@@ -97,6 +99,18 @@ export default function useWebsocketSetup() {
                 break;
             case SocketResponse.Error:
                 console.log(`Error Socket Response: ${parsedMessage.data.message}`);
+                break;
+            case SocketResponse.Correct:
+                console.log(`${parsedMessage.data.user} answered correctly!`);
+                setAnswers((prev) => [
+                    ...prev,
+                    {
+                        from: parsedMessage.data.username as string,
+                        answer: "",
+                        isCorrect: true,
+                    },
+                ]);
+
                 break;
             default:
                 console.log("Default in SocketResponse Switch. How did we get here...");
@@ -189,6 +203,9 @@ export default function useWebsocketSetup() {
                     playlist_indexes: playlistIndexes,
                 })
             );
+        },
+        broadcastCorrectAnswer: () => {
+            socketRef.current?.send(JSON.stringify({ type: SocketRequest.Correct }));
         },
         lobby,
         startSignal,

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -39,7 +39,6 @@ export default function useWebsocketSetup() {
     const [isHost, setIsHost] = useState(false);
     const [playlistUri, setPlaylistUri] = useState("");
     const [playlistIndexes, setPlaylistIndexes] = useState<number[]>([]);
-    const dispatch = useAppDispatch();
 
     const handleMessage = (message: MessageEvent) => {
         const parsedMessage = socketResponseSchema.safeParse(JSON.parse(message.data));

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -110,6 +110,17 @@ export default function useWebsocketSetup() {
                 console.log(`Error Socket Response: ${parsedMessage.data.message}`);
                 break;
             case SocketResponse.Correct:
+                const correctUsername = parsedMessage.data.username as string;
+
+                setLobby((lobby) => {
+                    const updatedLobby = { ...lobby };
+                    if (updatedLobby[correctUsername] === undefined) {
+                        console.error("Correct Response Received From Disconnected User..");
+                        return lobby;
+                    }
+                    updatedLobby[correctUsername].score += parsedMessage.data.score as number;
+                    return updatedLobby;
+                });
                 setAnswers((prev) => [
                     ...prev,
                     {
@@ -221,8 +232,14 @@ export default function useWebsocketSetup() {
                 })
             );
         },
-        broadcastCorrectAnswer: () => {
-            socketRef.current?.send(JSON.stringify({ type: SocketRequest.Correct }));
+        broadcastCorrectAnswer: (score: number) => {
+            socketRef.current?.send(
+                JSON.stringify({
+                    type: SocketRequest.Correct,
+                    username: user.username,
+                    score: score,
+                })
+            );
         },
         lobby,
         startSignal,

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -128,9 +128,13 @@ export default function useWebsocketSetup() {
 
     useEffect(() => {
         console.log("Running Websocket Setup..");
+        const timeout = setTimeout(() => {
+            window.location.href = "/";
+        }, 3000);
+
         if (!user.username) {
-            // throw new Error("Username undefined while establishing connection...");
             console.log(`Aborted Websocket Connection, Username is undefined...`);
+            window.location.href = "/";
             return;
         }
 
@@ -139,6 +143,7 @@ export default function useWebsocketSetup() {
 
         socketRef.current.onopen = () => {
             setLoading(false);
+            clearTimeout(timeout);
             console.log("Websocket connection established?");
         };
 
@@ -152,6 +157,7 @@ export default function useWebsocketSetup() {
         };
 
         return () => {
+            clearTimeout(timeout);
             console.log("Cleaning up Websocket connection..");
             socketRef.current?.close();
         };

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -15,6 +15,7 @@ enum SocketResponse {
     LeftRoom = "left-room",
     Playlist = "playlist",
     Correct = "correct",
+    Continue = "continue",
 }
 
 enum SocketRequest {
@@ -34,6 +35,7 @@ export default function useWebsocketSetup() {
     const [lobby, setLobby] = useState<string[]>([]);
     const [roomCode, setRoomCode] = useState("");
     const [startSignal, setStartSignal] = useState(false);
+    const [continueSignal, setContinueSignal] = useState<number>(0);
     const [isHost, setIsHost] = useState(false);
     const [playlistUri, setPlaylistUri] = useState("");
     const [playlistIndexes, setPlaylistIndexes] = useState<number[]>([]);
@@ -101,7 +103,6 @@ export default function useWebsocketSetup() {
                 console.log(`Error Socket Response: ${parsedMessage.data.message}`);
                 break;
             case SocketResponse.Correct:
-                console.log(`${parsedMessage.data.user} answered correctly!`);
                 setAnswers((prev) => [
                     ...prev,
                     {
@@ -111,6 +112,10 @@ export default function useWebsocketSetup() {
                     },
                 ]);
 
+                break;
+            case SocketResponse.Continue:
+                console.log("Received SocketResponse: Continue");
+                setContinueSignal((prev) => prev + 1);
                 break;
             default:
                 console.log("Default in SocketResponse Switch. How did we get here...");
@@ -209,6 +214,7 @@ export default function useWebsocketSetup() {
         },
         lobby,
         startSignal,
+        continueSignal,
         roomCode,
         isHost,
         playlistUri,

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -177,6 +177,9 @@ export default function useWebsocketSetup() {
             clearTimeout(timeout);
             console.log("Cleaning up Websocket connection..");
             socketRef.current?.close();
+            setLobby({});
+            setRoomCode("");
+            setStartSignal(false);
         };
     }, [user]);
 

--- a/client/src/hooks/useWebsocketSetup.tsx
+++ b/client/src/hooks/useWebsocketSetup.tsx
@@ -120,7 +120,6 @@ export default function useWebsocketSetup() {
             default:
                 console.log("Default in SocketResponse Switch. How did we get here...");
                 console.log(`${JSON.stringify(parsedMessage.data)}`);
-                console.log("Resetting RoomCode and StartSignal");
                 setRoomCode("");
                 setStartSignal(false);
         }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -38,5 +38,6 @@ export type PlaylistQuery = {
 export type Answer = {
   from: string,
   answer: string
+  isCorrect?: boolean
 }
 

--- a/server/src/handlers/roomHandler.ts
+++ b/server/src/handlers/roomHandler.ts
@@ -12,12 +12,15 @@ type DuelRooms = {
     [roomCode: string]: DuelRoom
 }
 
-type UserRoomMap = {
-  [username: string]: string
+type UserMap = {
+  [username: string]: {
+    roomCode: string,
+    answered_correctly: boolean
+  }
 }
 
 export const rooms: DuelRooms = {}
-export const userRoomMap: UserRoomMap = {}
+export const userMap: UserMap = {}
 
 const generateRoomCode = (length = 6) => {
     let code = ""
@@ -37,15 +40,15 @@ export const generateRoomHandler = async (req: Request, res: Response) => {
   
 
   //if this user already has a generated room, delete it before adding new one
-  if(userRoomMap[user]) {
-    const roomCode = userRoomMap[user]
+  if(userMap[user]?.roomCode) {
+    const roomCode = userMap[user].roomCode
     deleteRoom(roomCode)
   }
 
 
     const roomCode = generateRoomCode();
     rooms[roomCode] = { users: new Set(), interval_id: null };
-    userRoomMap[user] = roomCode
+    userMap[user] = {roomCode: roomCode, answered_correctly: false}
     console.log(`Rooms: ${JSON.stringify(rooms)}`);
     
     res.status(200).json({ roomCode: roomCode });

--- a/server/src/handlers/roomHandler.ts
+++ b/server/src/handlers/roomHandler.ts
@@ -1,9 +1,11 @@
 import { Request, Response } from "express"
 import { WebSocket } from "ws"
 import { respondWithError } from "../auth/utils"
+import {  deleteRoom } from "../websockets"
 
 type DuelRoom = {
-    users: Set<WebSocket>
+    users: Set<WebSocket>,
+    interval_id: NodeJS.Timeout | null
 }
 
 type DuelRooms = {
@@ -36,12 +38,13 @@ export const generateRoomHandler = async (req: Request, res: Response) => {
 
   //if this user already has a generated room, delete it before adding new one
   if(userRoomMap[user]) {
-    delete rooms[userRoomMap[user]]
+    const roomCode = userRoomMap[user]
+    deleteRoom(roomCode)
   }
 
 
     const roomCode = generateRoomCode();
-    rooms[roomCode] = { users: new Set() };
+    rooms[roomCode] = { users: new Set(), interval_id: null };
     userRoomMap[user] = roomCode
     console.log(`Rooms: ${JSON.stringify(rooms)}`);
     

--- a/server/src/handlers/roomHandler.ts
+++ b/server/src/handlers/roomHandler.ts
@@ -49,7 +49,7 @@ export const generateRoomHandler = async (req: Request, res: Response) => {
     const roomCode = generateRoomCode();
     rooms[roomCode] = { users: new Set(), interval_id: null };
     userMap[user] = {roomCode: roomCode, answered_correctly: false}
-    console.log(`Rooms: ${JSON.stringify(rooms)}`);
+    console.log(`Rooms: ${Object.keys(rooms)}`);
     
     res.status(200).json({ roomCode: roomCode });
 }

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -160,6 +160,9 @@ export const configureWebsocketServer = (server: Server) => {
             else if (parsedMessage.type === SocketRequest.StartDuel && parsedMessage.roomCode) {
                 sendMessageToRoom(parsedMessage.roomCode, {type: SocketResponse.StartDuel});
                 setContinueInterval(parsedMessage.roomCode, 30)
+                setTimeout(() => {
+                    sendMessageToRoom(parsedMessage.roomCode, { type: SocketResponse.Continue });
+                }, 1500)
             } 
             else if (parsedMessage.type === SocketRequest.LeaveRoom && roomCode) {
                 removeUserFromRoom(roomCode, ws);

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -19,7 +19,8 @@ enum SocketResponse {
     StartDuel = "start-duel",
     LeftRoom = "left-room",
     Playlist = "playlist",
-    Correct = "correct"
+    Correct = "correct",
+    Continue = "continue"
 }
 
 const userSocketMap = new Map<WebSocket, string>();
@@ -71,6 +72,12 @@ const removeUserFromRoom = (roomCode: string, socket: WebSocket) => {
 
 }
 
+const setContinueSignalTimer = (timeSeconds: number, roomCode: string) => {
+    setTimeout(() => {
+        sendMessageToRoom(roomCode, {type: SocketResponse.Continue})
+    }, timeSeconds * 1000)
+}
+
 export const configureWebsocketServer = (server: Server) => {
     const wss = new WebSocketServer({ server });
 
@@ -115,6 +122,7 @@ export const configureWebsocketServer = (server: Server) => {
                 }
             } else if (parsedMessage.type === SocketRequest.StartDuel && parsedMessage.roomCode) {
                 sendMessageToRoom(parsedMessage.roomCode, {type: SocketResponse.StartDuel})
+                setContinueSignalTimer(10, parsedMessage.roomCode)
             } else if(parsedMessage.type === SocketRequest.LeaveRoom && roomCode) {
                 removeUserFromRoom(roomCode, ws)
                 sendMessage(ws, {type: SocketResponse.LeftRoom})

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -20,6 +20,7 @@ enum SocketResponse {
     Playlist = "playlist",
     Correct = "correct",
     Continue = "continue",
+    UserDisconnected = "user-disconnected"
 }
 
 const userSocketMap = new Map<WebSocket, string>();
@@ -65,8 +66,7 @@ const removeUserFromRoom = (roomCode: string, socket: WebSocket) => {
             deleteRoom(roomCode)
             console.log(`Deleted empty room ${roomCode}`);
         } else {
-            const room = getUsersFromRoom(roomCode);
-            sendMessageToRoom(roomCode, { type: "room-update", room: room });
+            sendMessageToRoom(roomCode, { type: SocketResponse.UserDisconnected, user: user });
         }
     }
     if (userMap[user]) {
@@ -79,7 +79,7 @@ const resetLobbyCorrectAnswerFlags = (roomCode: string) => {
         const users = rooms[roomCode].users
         users.forEach(socket => {
             const username = userSocketMap.get(socket)
-            if(username) {
+            if(username && userMap[username]?.answered_correctly === true) {
                 userMap[username].answered_correctly = false
             }
         })

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -181,14 +181,13 @@ export const configureWebsocketServer = (server: Server) => {
                 });
             } 
             else if (parsedMessage.type === SocketRequest.Correct && roomCode && user) {
+                console.log(`Received Correct Request: ${JSON.stringify(parsedMessage)}`);
+                
                 if(!(user in userMap)) {
                     console.log("ERROR: CORRECT REQUEST RECEIVED FROM DISCONNECTED USER")
                     return
                 }
-                sendMessageToRoom(roomCode, {
-                    type: SocketResponse.Correct,
-                    username: user,
-                });
+                sendMessageToRoom(roomCode, parsedMessage);
                 userMap[user].answered_correctly = true
                 if(entireLobbyAnsweredCorrectly(roomCode))
                 {

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -181,12 +181,16 @@ export const configureWebsocketServer = (server: Server) => {
                 });
             } 
             else if (parsedMessage.type === SocketRequest.Correct && roomCode && user) {
+                if(!(user in userMap)) {
+                    console.log("ERROR: CORRECT REQUEST RECEIVED FROM DISCONNECTED USER")
+                    return
+                }
                 sendMessageToRoom(roomCode, {
                     type: SocketResponse.Correct,
                     username: user,
                 });
                 userMap[user].answered_correctly = true
-                if(rooms[roomCode].users.size > 1 && entireLobbyAnsweredCorrectly(roomCode))
+                if(entireLobbyAnsweredCorrectly(roomCode))
                 {
                     resetLobbyCorrectAnswerFlags(roomCode)
                     clearRoomInterval(roomCode)

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -1,13 +1,15 @@
 import { IncomingMessage, Server } from "http";
 import WebSocket, { WebSocketServer } from "ws";
 import { rooms, userRoomMap } from "./handlers/roomHandler";
+import { Socket } from "dgram";
 
 enum SocketRequest {
     JoinRoom = "join-room",
     LeaveRoom = "leave-room",
     StartDuel = "start-duel",
     SendPlaylist = "send-playlist",
-    Answer = "answer"
+    Answer = "answer",
+    Correct = "correct"
 }
 
 enum SocketResponse {
@@ -16,7 +18,8 @@ enum SocketResponse {
     Error = "error",
     StartDuel = "start-duel",
     LeftRoom = "left-room",
-    Playlist = "playlist"
+    Playlist = "playlist",
+    Correct = "correct"
 }
 
 const userSocketMap = new Map<WebSocket, string>();
@@ -123,6 +126,9 @@ export const configureWebsocketServer = (server: Server) => {
                 }
                 //to optimize, we can probably just return parsedMessage, since we're not transforming or adding any new data. Just relaying
                 sendMessageToRoom(roomCode, {type: SocketResponse.Playlist, playlist_uri: parsedMessage.playlist_uri, playlist_indexes: parsedMessage.playlist_indexes})
+            }
+            else if(parsedMessage.type === SocketRequest.Correct && roomCode && user) {
+                sendMessageToRoom(roomCode, {type: SocketResponse.Correct, username: user})
             }
             else {
                 wss.clients.forEach((client) => {

--- a/server/src/websockets.ts
+++ b/server/src/websockets.ts
@@ -187,6 +187,7 @@ export const configureWebsocketServer = (server: Server) => {
                 console.log(`Received Correct Request: ${JSON.stringify(parsedMessage)}`);
                 
                 if(!(user in userMap)) {
+                    console.log(Object.keys(userMap));
                     console.log("ERROR: CORRECT REQUEST RECEIVED FROM DISCONNECTED USER")
                     return
                 }


### PR DESCRIPTION
## Overview
- When host starts the game, the "start-duel" message is sent to the server
- It will then attach an interval id to sender's room object, which sends a "continue" signal to the room every 30 seconds.
- Setting the interval does not immediately invoke the function, so we manually send a "continue" message after 1.5 seconds of receiving the "start-duel" message
- When the client receives the **first** continue signal it starts and displays a 4 second timer, and then plays the first song.
- On **every other** continue signal, it will then start incrementing the `currentSongIndex`, selecting the next song
- If the entire lobby answers correctly, the server will reset its "continue signal" interval and immediately send a "continue" signal to the room
- Once the continue signal is greater than (length of track selection + 1), we know the game is over, and we display the Exit Lobby button
- Known Bugs
  - Rarely, the host will see score's of other players incremented twice. Random, haven't reproduced it
  - Rarely, when non-host sends the correct answer, server will return early due to the user not being in UserMap. However, this should only be the case if the user was never connected, or disconnected. Neither of these are true, as the user is able to send and receive messages. No idea  
## Issue
- https://github.com/JrodanDiaz/track-duel/issues/13
- https://github.com/JrodanDiaz/track-duel/issues/23
## Headaches
- The first `console.log` shows lobby as empty, but the one inside `setLobby()` shows the correct value, despite lobby not being updated yet. whyyyyyyyyy
![image](https://github.com/user-attachments/assets/db0bb8f6-1351-4e30-9e74-494f5011d152)
